### PR TITLE
set travis to upload builds release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
 language: java
 
 script: 02-Sourcecode/build.sh
+
+deploy:
+  provider: releases
+  api_key: "2f182947a3140029904d326eb597b2a5c23518b648fc1fc2e3dcbc222e1e22db"
+  file: "02-Sourcecode/nfscan-server/target/nfscan-server.war"
+  skip_cleanup: true
+  on:
+    tags: true


### PR DESCRIPTION
I've set travis.yml to upload the nfscan-server.war to repo releases when we tag a commit
