### PR TITLE
Fix #10 (IAM Role com erro na ARN)

### DIFF
--- a/04-Infrastructure/01-IAM/01-Development/nfscan_development_policy.json
+++ b/04-Infrastructure/01-IAM/01-Development/nfscan_development_policy.json
@@ -32,8 +32,8 @@
                 "sqs:SendMessage"
             ],
             "Resource": [
-                "arn:aws:sqs:sa-east-1:000000000000:DES-NFSCAN-OCR-PROCESS-IN",
-                "arn:aws:sqs:sa-east-1:000000000000:DES-NFSCAN-OCR-PROCESS-OUT"
+                "arn:aws:sqs:sa-east-1:*:DES-NFSCAN-OCR-PROCESS-IN",
+                "arn:aws:sqs:sa-east-1:*:DES-NFSCAN-OCR-PROCESS-OUT"
             ]
         },
         {
@@ -50,7 +50,7 @@
                 "dynamodb:DescribeTable"
             ],
             "Resource": [
-                "arn:aws:dynamodb:sa-east-1:000000000000:table/DES-NFSCAN-*"
+                "arn:aws:dynamodb:sa-east-1:*:table/DES-NFSCAN-*"
             ]
         },
         {


### PR DESCRIPTION
This issue removes the need of knowing the account id when configuring your IAM policies. The approach used was to use an wildcard operator instead of the account id as mentioned by @lucaskatayama
